### PR TITLE
マイグレーションファイルを修正

### DIFF
--- a/db/migrate/20210825073413_create_items.rb
+++ b/db/migrate/20210825073413_create_items.rb
@@ -1,9 +1,15 @@
 class CreateItems < ActiveRecord::Migration[6.0]
   def change
     create_table :items do |t|
-      t.string  :name,  null: false
-      t.integer :price, null:false
-      t.string  :maker, null: false
+      t.string  :name,    null: false
+      t.integer :price,   null: false
+      t.string  :maker,   null: false
+      t.string  :sound
+      t.string  :anc
+      t.string  :ambient
+      t.string  :type
+      t.string  :size
+      t.string  :codec
 
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,14 +37,14 @@ ActiveRecord::Schema.define(version: 2021_08_25_104830) do
     t.string "name", null: false
     t.integer "price", null: false
     t.string "maker", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
     t.string "sound"
     t.string "anc"
     t.string "ambient"
     t.string "type"
     t.string "size"
     t.string "codec"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
# What
itemsテーブルにカラムを追加するとき、ターミナルでmysql（データベース）を操作して直接カラムを追加したが、そのせいかマイグレーションファイルに記述されていなかったのでロールバックして記述し直した。